### PR TITLE
Fix IOCTLVersion code

### DIFF
--- a/codes.go
+++ b/codes.go
@@ -9,8 +9,8 @@ import (
 const IOCTLBase = 'd'
 
 var (
-	// DRM_IOR(0x0, struct drm_version)
-	IOCTLVersion = ioctl.NewCode(ioctl.Read,
+	// DRM_IOWR(0x00, struct drm_version)
+	IOCTLVersion = ioctl.NewCode(ioctl.Read|ioctl.Write,
 		uint16(unsafe.Sizeof(version{})), IOCTLBase, 0)
 
 	// DRM_IOWR(0x0c, struct drm_get_cap)


### PR DESCRIPTION
According to [libdrm](https://cgit.freedesktop.org/drm/libdrm/tree/include/drm/drm.h#n772), `DRM_IOCTL_VERSION` is defined as `DRM_IOWR` instead of `DRM_IOR`.

Without this change `drm.GetVersion()` always returns empty strings for the `Version.Name`, `Version.Desc` and `Version.Date` fields (I'm testing this on ArchLinux).